### PR TITLE
Set ObjectStatus in enclosure components

### DIFF
--- a/plugins-scripts/Classes/Dell/IDRAC/Components/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Dell/IDRAC/Components/EnvironmentalSubsystem.pm
@@ -466,17 +466,53 @@ package Classes::Dell::IDRAC::Components::EnclosureFan;
 our @ISA = qw(Classes::Dell::IDRAC::Components::ObjectStatusEnum);
 use strict;
 
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'enclosure fan (%s) status is %s',
+      $self->{enclosureFanNumber}, $self->{enclosureFanComponentStatus},
+  );
+  $self->{ObjectStatus} = $self->{enclosureFanComponentStatus};
+  $self->SUPER::check();
+}
+
 package Classes::Dell::IDRAC::Components::EnclosurePowerSupply;
 our @ISA = qw(Classes::Dell::IDRAC::Components::ObjectStatusEnum);
 use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'enclosure power supply (%s) status is %s',
+      $self->{enclosurePowerSupplyNumber}, $self->{enclosurePowerSupplyComponentStatus},
+  );
+  $self->{ObjectStatus} = $self->{enclosurePowerSupplyComponentStatus};
+  $self->SUPER::check();
+}
 
 package Classes::Dell::IDRAC::Components::EnclosureTemperatureProbe;
 our @ISA = qw(Classes::Dell::IDRAC::Components::ObjectStatusEnum);
 use strict;
 
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'enclosure temperature probe (%s) status is %s',
+      $self->{enclosureTemperatureProbeNumber}, $self->{enclosureTemperatureProbeComponentStatus},
+  );
+  $self->{ObjectStatus} = $self->{enclosureTemperatureProbeComponentStatus};
+  $self->SUPER::check();
+}
+
 package Classes::Dell::IDRAC::Components::EnclosureManagementModule;
 our @ISA = qw(Classes::Dell::IDRAC::Components::ObjectStatusEnum);
 use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'enclosure management module (%s) status is %s',
+      $self->{enclosureManagementModuleNumber}, $self->{enclosureManagementModuleComponentStatus},
+  );
+  $self->{ObjectStatus} = $self->{enclosureManagementModuleComponentStatus};
+  $self->SUPER::check();
+}
 
 package Classes::Dell::IDRAC::Components::Battery;
 our @ISA = qw(Classes::Dell::IDRAC::Components::ObjectStatusEnum);


### PR DESCRIPTION
We have servers with MD1400 drive enclosures connected to servers with iDRACs.  Running check_dell_health (as packaged in OMD Labs 4.40) against those results in errors within Classes::Dell::IDRAC::Components::ObjectStatusEnum::check() like this:

```
$ ./check_dell_health --community public --hostname drac.example -t 30 --mode hardware-health
Use of uninitialized value in string eq at ./check_dell_health line 220.
Use of uninitialized value in pattern match (m//) at ./check_dell_health line 222.
Use of uninitialized value in string eq at ./check_dell_health line 224.
```

This commit sets the ObjectStatus in Classes::Dell::IDRAC::Components::EnclosureFan, EnclosureManagementModule, EnclosureTemperatureProbe and EnclosurePowerSupply.